### PR TITLE
Implement secure email change flow

### DIFF
--- a/api/confirmEmailChange.js
+++ b/api/confirmEmailChange.js
@@ -1,14 +1,31 @@
-// POST /api/confirmEmailChange
-app.post('/api/confirmEmailChange', async (req, res) => {
-  const DEBUG = !!(process.env.RAV_DEBUG_EMAIL || process.env.DEBUG_EMAILS);
+/* eslint-env node */
+/* eslint-disable no-undef */
+const { createClient } = require('@supabase/supabase-js');
+const { sendEmail } = require('../lib/ses.cjs');
+const { niceEmail } = require('../lib/templates.cjs');
 
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const DEBUG = !!(process.env.RAV_DEBUG_EMAIL || process.env.DEBUG_EMAILS);
+
+module.exports = async (req, res) => {
+  const t0 = Date.now();
   try {
-    const { user_id, code } = req.body || {};
+    if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
+
+    const { user_id, code, debug } = req.body || {};
+    const dbg = DEBUG || !!debug;
+
+    if (dbg) console.log('[confirmEmailChange] BODY:', { user_id, code });
+
     if (!user_id || !code) {
+      if (dbg) console.log('[confirmEmailChange] Missing fields');
       return res.status(400).json({ error: 'Missing fields' });
     }
 
-    // 1) get latest valid code
     const { data: row, error: selErr } = await supabase
       .from('email_change_codes')
       .select('*')
@@ -20,19 +37,15 @@ app.post('/api/confirmEmailChange', async (req, res) => {
 
     if (selErr) throw selErr;
     if (!row) return res.status(400).json({ error: 'Invalid code' });
-    if (new Date(row.expires_at) < new Date()) {
-      return res.status(400).json({ error: 'Expired code' });
-    }
+    if (new Date(row.expires_at) < new Date()) return res.status(400).json({ error: 'Expired code' });
 
     const { old_email, new_email } = row;
+    if (dbg) console.log('[confirmEmailChange] Found row:', row);
 
-    // 2) change email A → B
-    const { error: updErr } = await supabase.auth.admin.updateUserById(user_id, {
-      email: new_email
-    });
+    const { error: updErr } = await supabase.auth.admin.updateUserById(user_id, { email: new_email });
     if (updErr) throw updErr;
+    console.log('[confirmEmailChange] Updated user email', old_email, '→', new_email);
 
-    // 3) kill ALL refresh tokens / sessions
     try {
       if (supabase.auth.admin.invalidateAllRefreshTokens) {
         await supabase.auth.admin.invalidateAllRefreshTokens(user_id);
@@ -47,7 +60,6 @@ app.post('/api/confirmEmailChange', async (req, res) => {
       console.warn('[confirmEmailChange] session revoke failed', e?.message);
     }
 
-    // 4) make a password reset link for B
     const { data: linkData, error: linkErr } = await supabase.auth.admin.generateLink({
       type: 'recovery',
       email: new_email
@@ -55,22 +67,19 @@ app.post('/api/confirmEmailChange', async (req, res) => {
     if (linkErr) throw linkErr;
 
     const actionLink = linkData?.properties?.action_link || null;
-    if (!actionLink) {
-      throw new Error('No action_link from Supabase');
-    }
+    if (!actionLink) throw new Error('No action_link from Supabase');
 
-    // 5) send warn to A
     const warnSubject = 'Your RavGrowth account email changed';
     const warnHtml = niceEmail({
       title: 'Your RavGrowth account email changed',
-      bodyHtml: `<p>Your account email was changed to <b>${new_email}</b>.</p>
+      bodyHTML: `<p>Your account email was changed to <b>${new_email}</b>.</p>
                  <p>If this wasn’t you, please secure your account now.</p>`,
-      ctaText: 'Reset password',
-      ctaHref: actionLink
+      buttonText: 'Reset password',
+      buttonLink: actionLink
     });
     const warnText = `Your email changed to ${new_email}. If this was not you, reset here: ${actionLink}`;
 
-    if (DEBUG) {
+    if (dbg) {
       console.log('[confirmEmailChange] WARN OLD EMAIL PREVIEW ->', {
         to: old_email, subject: warnSubject, text: warnText, htmlLength: warnHtml.length
       });
@@ -84,18 +93,17 @@ app.post('/api/confirmEmailChange', async (req, res) => {
       });
     }
 
-    // 6) send confirm to B with reset CTA
     const okSubject = 'Email updated - set a new password';
     const okHtml = niceEmail({
       title: 'Email updated',
-      bodyHtml: `<p>Your account email is now <b>${new_email}</b>.</p>
+      bodyHTML: `<p>Your account email is now <b>${new_email}</b>.</p>
                  <p>For safety, please set a new password now.</p>`,
-      ctaText: 'Set new password',
-      ctaHref: actionLink
+      buttonText: 'Set new password',
+      buttonLink: actionLink
     });
     const okText = `Email updated to ${new_email}. Set a new password: ${actionLink}`;
 
-    if (DEBUG) {
+    if (dbg) {
       console.log('[confirmEmailChange] OK NEW EMAIL PREVIEW ->', {
         to: new_email, subject: okSubject, text: okText, htmlLength: okHtml.length
       });
@@ -109,19 +117,19 @@ app.post('/api/confirmEmailChange', async (req, res) => {
       });
     }
 
-    // 7) done — also tell front end to logout
     console.log('[confirmEmailChange] SUCCESS payload:', {
       user_id, old_email, new_email, actionLink
     });
 
     return res.json({
       ok: true,
+      resetLink: linkData,
       action_link: actionLink,
-      forceLogout: true // front-end can check this and call hardLogout()
+      forceLogout: true,
+      tookMs: Date.now() - t0
     });
-
   } catch (err) {
     console.error('[confirmEmailChange]', err);
     return res.status(500).json({ error: String(err.message || err) });
   }
-});
+};

--- a/src/pages/ChangeEmail.jsx
+++ b/src/pages/ChangeEmail.jsx
@@ -1,6 +1,4 @@
 import { useEffect, useState } from "react";
-import { hardLogout } from "./logout";
-// "C:\Users\guita\ravbot-dashboard\src\pages\logout.jsx"
 import { supabase } from "../supabaseClient";
 
 export default function ChangeEmail() {
@@ -136,6 +134,15 @@ export default function ChangeEmail() {
 
       if (!r.ok) {
         return banner(data?.error || "Invalid or expired code.", "red");
+      }
+
+      if (data?.forceLogout) {
+        console.log('[ChangeEmail] forceLogout received - signing out');
+        try {
+          await supabase.auth.signOut();
+        } catch (e) {
+          console.log('[ChangeEmail] signOut error', e);
+        }
       }
 
       // Store reset link if provided by backend
@@ -345,12 +352,12 @@ export default function ChangeEmail() {
             <button onClick={() => (window.location.href = "/dashboard")} style={btnGhost}>
               Return to Dashboard
             </button>
-              <button
+            <button
               onClick={() => {
                 window.location.href =
                   `/login#message=${encodeURIComponent(
                     'Email updated - check your inbox to reset your password.'
-                  )}&emailChange=success`;
+                  )}&emailChange=success&prefill=${encodeURIComponent(verifiedNewEmail)}`;
               }}
               style={btnGhost}
             >
@@ -359,7 +366,10 @@ export default function ChangeEmail() {
             <button
               onClick={async () => {
                 await supabase.auth.signOut();
-                window.location.href = "/login#message=" + encodeURIComponent("Sign in with your NEW email to continue.");
+                window.location.href =
+                  "/login#message=" +
+                  encodeURIComponent("Sign in with your NEW email to continue.") +
+                  `&prefill=${encodeURIComponent(verifiedNewEmail)}`;
               }}
               style={btnGhost}
             >

--- a/src/pages/login.jsx
+++ b/src/pages/login.jsx
@@ -83,6 +83,16 @@ export default function Login() {
     });
   }, []);
 
+  useEffect(() => {
+    const hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+    const queryParams = new URLSearchParams(window.location.search);
+    const prefill = hashParams.get('prefill') || queryParams.get('prefill');
+    if (prefill) {
+      console.log('[Login] prefilled email:', prefill);
+      setEmail(prefill);
+    }
+  }, []);
+
   async function handleAuth() {
     if (mode === 'login') {
       const { error } = await supabase.auth.signInWithPassword({ email, password });


### PR DESCRIPTION
## Summary
- add serverless endpoint to confirm email changes, revoke sessions, and send warning/reset emails
- force logout after email switch and pass new address to login screen
- prefill login form from redirect to streamline password reset

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 23 errors)*
- `npx eslint api/confirmEmailChange.js src/pages/ChangeEmail.jsx src/pages/login.jsx`

------
https://chatgpt.com/codex/tasks/task_e_6897e8eb572c832eb76b0ffd24ac073a