### PR TITLE
feat: add account deletion

### DIFF
--- a/api/deleteAccount.js
+++ b/api/deleteAccount.js
@@ -1,0 +1,33 @@
+/* eslint-env node */
+const { createClient } = require('@supabase/supabase-js');
+const { assertEnv } = require('../lib/env.cjs');
+const logger = require('../lib/logger.cjs');
+
+assertEnv(['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY']);
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+module.exports = async (req, res) => {
+  try {
+    if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
+
+    const { user_id } = req.body || {};
+    if (!user_id) return res.status(400).json({ error: 'Missing user_id' });
+
+    await supabase.from('profiles').delete().eq('id', user_id);
+    await supabase.from('settings').delete().eq('user_id', user_id);
+    await supabase.from('linked_records').delete().eq('user_id', user_id);
+
+    const { error } = await supabase.auth.admin.deleteUser(user_id, { shouldSoftDelete: false });
+    if (error) throw error;
+
+    return res.json({ success: true });
+  } catch (e) {
+    logger.error('deleteAccount', e);
+    return res.status(500).json({ error: e.message });
+  }
+};
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import Login from "./pages/login.jsx";
 import Reset from "./pages/reset.jsx";
 import Dashboard from "./pages/dashboard.jsx";
 import ChangeEmail from './pages/ChangeEmail.jsx';
+import Settings from './pages/settings.jsx';
 
 function MessageBanner() {
   const [message, setMessage] = useState(null);
@@ -82,6 +83,7 @@ function AppWrapper() {
         <Route path="/dashboard" element={session ? <Dashboard /> : <Login />} />
         <Route path="/reset/*" element={<Reset />} />
         <Route path="/change-email" element={<ChangeEmail />} />
+        <Route path="/settings" element={<Settings />} />
       </Routes>
     </>
   );

--- a/src/pages/dashboard.jsx
+++ b/src/pages/dashboard.jsx
@@ -23,6 +23,7 @@ export default function Dashboard() {
     <div style={{ padding: 40 }}>
       <h1>🔥 Welcome to RavBot Dashboard 🔥</h1>
       <p>Logged in as: {session.user.email}</p>
+      <button onClick={() => (window.location.href = "/settings")}>Settings</button>
       <button onClick={async () => {
         await supabase.auth.signOut();
         window.location.href = "/login";

--- a/src/pages/settings.jsx
+++ b/src/pages/settings.jsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from "react";
+import { supabase } from "../supabaseClient";
+
+const API_ORIGIN = import.meta.env.VITE_API_ORIGIN || "";
+
+export default function Settings() {
+  const [session, setSession] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  const [showModal, setShowModal] = useState(false);
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const checkSession = async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) window.location.href = "/";
+      else {
+        setSession(session);
+        setLoading(false);
+      }
+    };
+    checkSession();
+  }, []);
+
+  async function handleDelete() {
+    setError("");
+    if (!password) {
+      setError("Enter your password.");
+      return;
+    }
+
+    const { error: signInError } = await supabase.auth.signInWithPassword({
+      email: session.user.email,
+      password
+    });
+    if (signInError) {
+      setError("Incorrect password.");
+      return;
+    }
+
+    try {
+      const r = await fetch(`${API_ORIGIN}/api/deleteAccount`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ user_id: session.user.id })
+      });
+      if (!r.ok) {
+        const data = await r.json().catch(() => ({}));
+        setError(data?.error || "Failed to delete account.");
+        return;
+      }
+    } catch (err) {
+      console.error(err);
+      setError("Failed to delete account.");
+      return;
+    }
+
+    await supabase.auth.signOut();
+    window.location.href = `/#message=${encodeURIComponent("Your account has been deleted.")}`;
+  }
+
+  if (loading) return <p>Loading...</p>;
+
+  return (
+    <div style={{ padding: 40 }}>
+      <h1>Settings</h1>
+      <button onClick={() => setShowModal(true)}>Delete Account</button>
+      {showModal && (
+        <div
+          style={{
+            position: "fixed",
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            background: "rgba(0,0,0,0.5)",
+            display: "grid",
+            placeItems: "center"
+          }}
+        >
+          <div style={{ background: "white", padding: 20, maxWidth: 400 }}>
+            <p>
+              This will permanently delete your account and all associated data. This action cannot be undone.
+            </p>
+            <input
+              type="password"
+              placeholder="Current password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              style={{ width: "100%", marginTop: 8 }}
+            />
+            {error && <p style={{ color: "red" }}>{error}</p>}
+            <div style={{ display: "flex", gap: 8, marginTop: 16 }}>
+              <button onClick={handleDelete}>Delete My Account</button>
+              <button
+                onClick={() => {
+                  setShowModal(false);
+                  setPassword("");
+                  setError("");
+                }}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add settings page with delete account modal and reauth
- wire up backend endpoint to remove account data
- add settings route and dashboard link

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898029df164832e9b2abb3cd959db4a