### PR TITLE
feat: revamp dashboard with editable transactions and RLS

### DIFF
--- a/src/components/BankConnections.jsx
+++ b/src/components/BankConnections.jsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../supabaseClient.js';
+import { usePlaidLink } from 'react-plaid-link';
+import Card from './Card.jsx';
+
+export default function BankConnections({ userId }) {
+  const [linkToken, setLinkToken] = useState(null);
+  const [banks, setBanks] = useState([]);
+
+  useEffect(() => {
+    const fetchBanks = async () => {
+      const { data } = await supabase
+        .from('bank_connections')
+        .select('id, institution_name, institution_id')
+        .eq('user_id', userId)
+        .order('created_at', { ascending: false });
+      setBanks(data || []);
+    };
+    fetchBanks();
+  }, [userId]);
+
+  useEffect(() => {
+    const createLinkToken = async () => {
+      const res = await fetch('/api/linkToken', { method: 'POST' });
+      const data = await res.json();
+      setLinkToken(data.link_token);
+    };
+    createLinkToken();
+  }, []);
+
+  const { open, ready } = usePlaidLink({
+    token: linkToken,
+    onSuccess: async (public_token, metadata) => {
+      const bankName = metadata.institution?.name;
+      const bankId = metadata.institution?.institution_id;
+      const res = await fetch('/api/exchangePublicToken', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ public_token, bankName, bankId, userId }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setBanks((prev) => [...prev, data.bank]);
+      } else {
+        console.error(data.error);
+        alert('Failed to link bank');
+      }
+    },
+  });
+
+  return (
+    <Card
+      title="Bank Connections"
+      actions={
+        <button onClick={() => open()} disabled={!ready || !linkToken}>
+          Connect Bank
+        </button>
+      }
+    >
+      {banks.length === 0 ? (
+        <p>No banks connected</p>
+      ) : (
+        <ul style={{ listStyle: 'none', padding: 0 }}>
+          {banks.map((b) => (
+            <li key={b.id}>{b.institution_name}</li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  );
+}

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,0 +1,13 @@
+export default function Card({ title, actions, children }) {
+  return (
+    <div style={{ border: '1px solid #ddd', borderRadius: '8px', padding: '1rem', marginBottom: '1rem' }}>
+      {title && (
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.5rem' }}>
+          <h3 style={{ margin: 0 }}>{title}</h3>
+          {actions}
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/src/components/DownloadCsvButton.jsx
+++ b/src/components/DownloadCsvButton.jsx
@@ -1,0 +1,59 @@
+import { supabase } from '../supabaseClient.js';
+
+export default function DownloadCsvButton({ userId }) {
+  const handleDownload = async () => {
+    const { data: txns } = await supabase
+      .from('transactions')
+      .select('transaction_id, date, merchant_name, name, amount')
+      .eq('user_id', userId)
+      .order('date', { ascending: false })
+      .limit(200);
+
+    const { data: ovs } = await supabase
+      .from('transaction_overrides')
+      .select('transaction_id, category, notes')
+      .eq('user_id', userId);
+
+    const overrides = {};
+    (ovs || []).forEach((o) => {
+      overrides[o.transaction_id] = o;
+    });
+
+    const header = ['date', 'merchant', 'raw_name', 'amount', 'category', 'notes'];
+    const rows = (txns || []).map((t) => {
+      const o = overrides[t.transaction_id] || {};
+      return {
+        date: t.date,
+        merchant: t.merchant_name || '',
+        raw_name: t.name || '',
+        amount: t.amount,
+        category: o.category || '',
+        notes: o.notes || '',
+      };
+    });
+
+    const csv = [
+      header.join(','),
+      ...rows.map((r) =>
+        [
+          r.date,
+          `"${(r.merchant || '').replace(/"/g, '""')}`,
+          `"${(r.raw_name || '').replace(/"/g, '""')}`,
+          r.amount,
+          r.category,
+          `"${(r.notes || '').replace(/"/g, '""')}`,
+        ].join(',')
+      ),
+    ].join('\n');
+
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'transactions.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return <button onClick={handleDownload}>Download CSV</button>;
+}

--- a/src/components/EditTransactionModal.jsx
+++ b/src/components/EditTransactionModal.jsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+
+export default function EditTransactionModal({ transaction, override = {}, onClose, onSave }) {
+  const [category, setCategory] = useState(override.category || '');
+  const [notes, setNotes] = useState(override.notes || '');
+  const categories = ['Food', 'Rent', 'Utilities', 'Entertainment', 'Travel', 'Shopping', 'Other'];
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: 'rgba(0,0,0,0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <div style={{ background: '#fff', padding: '1rem', borderRadius: '8px', width: '300px' }}>
+        <h3>Edit Transaction</h3>
+        <div style={{ marginBottom: '0.5rem' }}>
+          <label>
+            Category
+            <select value={category} onChange={(e) => setCategory(e.target.value)} style={{ width: '100%' }}>
+              <option value="">-- Select --</option>
+              {categories.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <div style={{ marginBottom: '0.5rem' }}>
+          <label>
+            Notes
+            <textarea value={notes} onChange={(e) => setNotes(e.target.value)} style={{ width: '100%' }} />
+          </label>
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
+          <button onClick={onClose}>Cancel</button>
+          <button onClick={() => onSave(transaction.transaction_id, category, notes)}>Save</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/HeaderBar.jsx
+++ b/src/components/HeaderBar.jsx
@@ -1,0 +1,13 @@
+import LogoutButton from './LogoutButton.jsx';
+
+export default function HeaderBar({ user }) {
+  return (
+    <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
+      <h1 style={{ margin: 0 }}>RavBot Dashboard</h1>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+        <span>{user.email}</span>
+        <LogoutButton />
+      </div>
+    </header>
+  );
+}

--- a/src/components/Subscriptions.jsx
+++ b/src/components/Subscriptions.jsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../supabaseClient.js';
+import Card from './Card.jsx';
+
+const labels = {
+  detected: 'Detected',
+  cancel_pending: 'Cancel Pending',
+  cancelled: 'Cancelled',
+};
+
+export default function Subscriptions({ userId }) {
+  const [subs, setSubs] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchSubs = async () => {
+      setLoading(true);
+      const { data } = await supabase
+        .from('subscriptions')
+        .select('id, name, status')
+        .eq('user_id', userId);
+      setSubs(data || []);
+      setLoading(false);
+    };
+    fetchSubs();
+  }, [userId]);
+
+  return (
+    <Card title="Subscriptions">
+      {loading ? (
+        <p>Loading...</p>
+      ) : subs.length === 0 ? (
+        <p>No subscriptions found</p>
+      ) : (
+        <ul style={{ listStyle: 'none', padding: 0 }}>
+          {subs.map((s) => (
+            <li
+              key={s.id}
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                padding: '0.25rem 0',
+                borderBottom: '1px solid #eee',
+              }}
+            >
+              <span>{s.name}</span>
+              <span
+                style={{
+                  fontSize: '0.8rem',
+                  background: '#eee',
+                  borderRadius: '4px',
+                  padding: '0 0.5rem',
+                }}
+              >
+                {labels[s.status] || s.status}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  );
+}

--- a/src/components/Transactions.jsx
+++ b/src/components/Transactions.jsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../supabaseClient.js';
+import EditTransactionModal from './EditTransactionModal.jsx';
+
+export default function Transactions({ userId, limit = 200 }) {
+  const [transactions, setTransactions] = useState([]);
+  const [overrides, setOverrides] = useState({});
+  const [loading, setLoading] = useState(true);
+  const [editing, setEditing] = useState(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      const { data: txns } = await supabase
+        .from('transactions')
+        .select('transaction_id, date, merchant_name, name, amount, user_id')
+        .eq('user_id', userId)
+        .order('date', { ascending: false })
+        .limit(limit);
+
+      const { data: ovs } = await supabase
+        .from('transaction_overrides')
+        .select('transaction_id, category, notes')
+        .eq('user_id', userId);
+
+      const map = {};
+      (ovs || []).forEach((o) => {
+        map[o.transaction_id] = o;
+      });
+
+      setOverrides(map);
+      setTransactions(txns || []);
+      setLoading(false);
+    };
+    fetchData();
+  }, [userId, limit]);
+
+  const grouped = transactions.reduce((acc, t) => {
+    const date = t.date;
+    acc[date] = acc[date] || [];
+    acc[date].push(t);
+    return acc;
+  }, {});
+  const dates = Object.keys(grouped).sort((a, b) => new Date(b) - new Date(a));
+
+  const handleSave = async (transactionId, category, notes) => {
+    await supabase.from('transaction_overrides').upsert(
+      {
+        user_id: userId,
+        transaction_id: transactionId,
+        category,
+        notes,
+      },
+      { onConflict: 'user_id,transaction_id' }
+    );
+    setOverrides((prev) => ({ ...prev, [transactionId]: { category, notes } }));
+    setEditing(null);
+  };
+
+  if (loading) return <p>Loading...</p>;
+  if (transactions.length === 0) return <p>No transactions</p>;
+
+  return (
+    <div>
+      {dates.map((date) => (
+        <div key={date} style={{ marginBottom: '1rem' }}>
+          <h4 style={{ margin: '0.5rem 0' }}>{date}</h4>
+          <ul style={{ listStyle: 'none', padding: 0 }}>
+            {grouped[date].map((t) => {
+              const override = overrides[t.transaction_id] || {};
+              const amount = typeof t.amount === 'number' ? t.amount.toFixed(2) : t.amount;
+              return (
+                <li
+                  key={t.transaction_id}
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    padding: '0.25rem 0',
+                    borderBottom: '1px solid #eee',
+                  }}
+                >
+                  <div>
+                    <strong>{t.merchant_name || t.name}</strong>
+                    {t.merchant_name && t.name && (
+                      <div style={{ fontSize: '0.8rem', color: '#555' }}>{t.name}</div>
+                    )}
+                    {override.category && (
+                      <div style={{ fontSize: '0.8rem', color: '#555' }}>
+                        Category: {override.category}
+                      </div>
+                    )}
+                    {override.notes && (
+                      <div style={{ fontSize: '0.8rem', color: '#555' }}>Notes: {override.notes}</div>
+                    )}
+                  </div>
+                  <div style={{ textAlign: 'right' }}>
+                    <div style={{ fontWeight: 'bold' }}>${amount}</div>
+                    <button onClick={() => setEditing(t)}>Edit</button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ))}
+      {editing && (
+        <EditTransactionModal
+          transaction={editing}
+          override={overrides[editing.transaction_id]}
+          onClose={() => setEditing(null)}
+          onSave={handleSave}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/pages/dashboard.jsx
+++ b/src/pages/dashboard.jsx
@@ -1,253 +1,47 @@
-import { useEffect, useState } from "react";
-import { supabase } from "../supabaseClient";
-import { usePlaidLink } from "react-plaid-link";
+import { useEffect, useState } from 'react';
+import { supabase } from '../supabaseClient.js';
+import HeaderBar from '../components/HeaderBar.jsx';
+import Transactions from '../components/Transactions.jsx';
+import BankConnections from '../components/BankConnections.jsx';
+import Subscriptions from '../components/Subscriptions.jsx';
+import DownloadCsvButton from '../components/DownloadCsvButton.jsx';
+import Card from '../components/Card.jsx';
 
 export default function Dashboard() {
   const [session, setSession] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [subs, setSubs] = useState([]);
-  const [linkToken, setLinkToken] = useState(null);
-  const [banks, setBanks] = useState([]); // connected banks
-  const [accounts, setAccounts] = useState({});
-  const [transactions, setTransactions] = useState({});
 
-  // ---------------------------
-  // Auth + subscriptions
-  // ---------------------------
   useEffect(() => {
     const checkSession = async () => {
-      const { data: { session } } = await supabase.auth.getSession();
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
       if (!session) {
-        window.location.href = "/";
+        window.location.href = '/';
       } else {
         setSession(session);
         setLoading(false);
-
-        try {
-          const res = await fetch("/api/subscriptions/scan");
-          if (res.ok) {
-            const data = await res.json();
-            setSubs(data.subscriptions || []);
-          } else {
-            console.warn("scan endpoint not available yet");
-          }
-        } catch (e) {
-          console.error("scan failed", e);
-        }
-
-        // fetch connected banks
-        try {
-          const { data: banksData } = await supabase
-            .from("bank_connections")
-            .select("id, institution_name, institution_id, is_test, created_at")
-            .eq("user_id", session.user.id);
-          setBanks(banksData || []);
-        } catch (e) {
-          console.error("failed to fetch banks", e);
-        }
       }
     };
     checkSession();
   }, []);
 
-  // ---------------------------
-  // Fetch link_token on load
-  // ---------------------------
-  useEffect(() => {
-    const createLinkToken = async () => {
-      try {
-        const res = await fetch("/api/linkToken", { method: "POST" });
-        const data = await res.json();
-        setLinkToken(data.link_token);
-      } catch (err) {
-        console.error("failed to create link token", err);
-      }
-    };
-    createLinkToken();
-  }, []);
-
-  // ---------------------------
-  // Plaid hook
-  // ---------------------------
-  const { open, ready } = usePlaidLink({
-    token: linkToken,
-    onSuccess: async (public_token, metadata) => {
-      const bankName = metadata.institution?.name;
-      const bankId = metadata.institution?.institution_id;
-      const userId = session.user.id;
-
-      try {
-        const res = await fetch("/api/exchangePublicToken", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ public_token, bankName, bankId, userId }),
-        });
-        const data = await res.json();
-        if (!res.ok) throw new Error(data.error || "Exchange failed");
-
-        // add new bank to state
-        setBanks((prev) => [...prev, data.bank]);
-      } catch (err) {
-        console.error("exchange failed", err);
-        alert("Failed to link bank");
-      }
-    },
-  });
-
-  // ---------------------------
-  // Fetch accounts/transactions
-  // ---------------------------
-  async function fetchAccounts(bankConnectionId) {
-    try {
-      const res = await fetch("/api/getAccounts", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ userId: session.user.id, bankConnectionId }),
-      });
-      const data = await res.json();
-      setAccounts((prev) => ({ ...prev, [bankConnectionId]: data.accounts || [] }));
-    } catch (err) {
-      console.error("failed to fetch accounts", err);
-    }
-  }
-
-  async function fetchTransactions(bankConnectionId) {
-    try {
-      const res = await fetch("/api/getTransactions", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ userId: session.user.id, bankConnectionId }),
-      });
-      const data = await res.json();
-      setTransactions((prev) => ({ ...prev, [bankConnectionId]: data.transactions || [] }));
-    } catch (err) {
-      console.error("failed to fetch transactions", err);
-    }
-  }
-
-  async function fetchAllTransactions() {
-    for (let bank of banks.filter(Boolean)) {
-      if (bank?.id) {
-        console.log("trying to do this: Banks in state when loading all txns:", banks);
-        await fetchTransactions(bank.id);
-        console.log("Banks in state when loading all txns:", banks);
-      }
-    }
-  }
-
-  // ---------------------------
-  // Render
-  // ---------------------------
   if (loading) return <p>Loading...</p>;
 
   return (
-    <div style={{ padding: 40 }}>
-      <h1>🔥 Welcome to RavBot Dashboard 🔥</h1>
-      <p>Logged in as: {session.user.email}</p>
-
-      <button onClick={() => (window.location.href = "/settings")}>Settings</button>
-      <button
-        onClick={async () => {
-          await supabase.auth.signOut();
-          window.location.href = "/login";
-        }}
-      >
-        Log Out
-      </button>
-
-      {/* ---------------------------
-          Bank Connections
-      --------------------------- */}
-      <h2>Bank Connections</h2>
-      <button
-        onClick={() => open()}
-        disabled={!ready || !linkToken}
-        style={{ marginBottom: "1rem" }}
-      >
-        Connect Bank
-      </button>
-
-      {banks && banks.length > 0 ? (
-        <ul>
-          {banks.filter(Boolean).map((b) => (
-            <li key={b.id} style={{ marginBottom: "1rem" }}>
-              ✅ {b.institution_name} (ID: {b.institution_id})
-              <div style={{ marginTop: "0.5rem" }}>
-                <button onClick={() => fetchAccounts(b.id)}>Load Accounts</button>
-                <button onClick={() => fetchTransactions(b.id)}>Load Transactions</button>
-              </div>
-
-              {/* Accounts */}
-              {accounts[b.id] && accounts[b.id].length > 0 && (
-                <ul>
-                  {accounts[b.id].map((acc) => (
-                    <li key={acc.account_id}>
-                      {acc.name} – ${acc.balances.current}
-                    </li>
-                  ))}
-                </ul>
-              )}
-
-              {/* Transactions */}
-              {transactions[b.id] && transactions[b.id].length > 0 && (
-                <ul>
-                  {transactions[b.id].map((t) => (
-                    <li key={t.transaction_id}>
-                      {t.date}: {t.name} – ${t.amount}
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <p>No banks connected yet.</p>
-      )}
-
-      {banks.length > 0 && (
-        <button onClick={fetchAllTransactions} style={{ marginTop: "1rem" }}>
-          Load All Transactions
-        </button>
-      )}
-
-      {/* ---------------------------
-          Subscriptions
-      --------------------------- */}
-      <h2>Subscriptions</h2>
-      {subs.length === 0 ? (
-        <p>No subscriptions</p>
-      ) : (
-        <ul>
-          {subs.map((s) => (
-            <li key={s.id}>
-              {s.name}{" "}
-              {s.status === "cancelled" ? (
-                "(Cancelled)"
-              ) : (
-                <button
-                  onClick={async () => {
-                    try {
-                      const res = await fetch("/api/subscriptions/cancel", {
-                        method: "POST",
-                        headers: { "Content-Type": "application/json" },
-                        body: JSON.stringify({ subscriptionId: s.id }),
-                      });
-                      if (!res.ok) throw new Error("Request failed");
-                      setSubs((prev) => prev.filter((x) => x.id !== s.id));
-                    } catch (err) {
-                      console.error(err);
-                      alert("Failed to cancel");
-                    }
-                  }}
-                >
-                  Cancel
-                </button>
-              )}
-            </li>
-          ))}
-        </ul>
-      )}
+    <div style={{ padding: '1rem' }}>
+      <HeaderBar user={session.user} />
+      <div style={{ display: 'flex', gap: '1rem', alignItems: 'flex-start' }}>
+        <div style={{ flex: 1 }}>
+          <Card title="Transactions" actions={<DownloadCsvButton userId={session.user.id} />}>
+            <Transactions userId={session.user.id} limit={200} />
+          </Card>
+        </div>
+        <div style={{ flex: 1 }}>
+          <BankConnections userId={session.user.id} />
+          <Subscriptions userId={session.user.id} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/supabase/migrations/20250213000000_add_transaction_overrides_and_rls.sql
+++ b/supabase/migrations/20250213000000_add_transaction_overrides_and_rls.sql
@@ -1,0 +1,26 @@
+create table if not exists transaction_overrides (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id) on delete cascade,
+  transaction_id text not null,
+  category text,
+  notes text,
+  created_at timestamptz default now(),
+  unique (user_id, transaction_id)
+);
+
+alter table transactions enable row level security;
+alter table transaction_overrides enable row level security;
+alter table subscriptions enable row level security;
+
+create policy "Users select own transactions" on transactions
+  for select using (auth.uid() = user_id);
+
+create policy "Users insert own transactions" on transactions
+  for insert with check (auth.uid() = user_id);
+
+create policy "Users manage own overrides" on transaction_overrides
+  for all using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "Users select own subscriptions" on subscriptions
+  for select using (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add modular dashboard with transactions, bank links, and subscriptions
- enable transaction editing with overrides and CSV export
- secure user data with Supabase RLS policies

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7181c5a40832e93945c73d7178cba